### PR TITLE
Fix markdown typo in article.py comment

### DIFF
--- a/nemulow/article.py
+++ b/nemulow/article.py
@@ -166,7 +166,7 @@ class Article:
         Decorate the raw content with HTML tags.
         Some markdown syntax is supported.
 
-        The following markdwon syntax is supported:
+        The following markdown syntax is supported:
         - **string** : bold
         - `code` : code
         - [alt text](url) : link


### PR DESCRIPTION
## Summary
- fix a typo in `nemulow/article.py` docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e121d944832d885bdd5b4594f89b