### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/nemulow/article.py
+++ b/nemulow/article.py
@@ -143,7 +143,7 @@ class Article:
             if in_comment:
                 if '-->' in line:
                     in_comment = False
-                    line = re.sub(r'.*-->', '', line)
+                    line = re.sub(r'.*-->', '', line, flags=re.DOTALL)
                 else:
                     line = ''
             remove_commented_lines.append(line)


### PR DESCRIPTION
Potential fix for [https://github.com/keioni/nemulow/security/code-scanning/10](https://github.com/keioni/nemulow/security/code-scanning/10)

To fix the problem, the regular expression used to match the end of an HTML comment (`.*-->`) should be updated to match across multiple lines. This can be achieved by adding the `re.DOTALL` flag to the `re.sub` call, which allows the `.` character to match newline characters. Specifically, in the `_remove_comments` method, on line 146, the call to `re.sub(r'.*-->', '', line)` should be changed to `re.sub(r'.*-->', '', line, flags=re.DOTALL)`. This change ensures that comments ending with `-->` are correctly removed even if they span multiple lines. No additional imports are needed, as `re` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
