### PR TITLE
Potential fix for code scanning alert no. 9: Bad HTML filtering regexp

### DIFF
--- a/nemulow/article.py
+++ b/nemulow/article.py
@@ -134,7 +134,7 @@ class Article:
         for line in self.raw_content:
             if '<!--' in line:
                 if '-->' in line:
-                    line = re.sub(r'<!--.*-->', '', line)
+                    line = re.sub(r'<!--.*-->', '', line, flags=re.DOTALL)
                 else:
                     line = re.sub(r'<!--.*', '', line)
                     in_comment = True


### PR DESCRIPTION
Potential fix for [https://github.com/keioni/nemulow/security/code-scanning/9](https://github.com/keioni/nemulow/security/code-scanning/9)

To fix the problem, the regular expression used to match HTML comments on line 137 should be updated to handle comments that span multiple lines. This can be achieved by adding the `re.DOTALL` flag to the `re.sub` call, so that the `.` wildcard matches newline characters as well. This change should be made only to the line where the regex is used, and no other functionality should be altered. No new methods or definitions are needed, but the `flags=re.DOTALL` argument should be added to the `re.sub` call on line 137.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
